### PR TITLE
feat: [CHA-2956] connection pooling: getstream-ruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,43 @@
 
 [Spec](https://www.notion.so/stream-wiki/Server-Side-SDK-Webhook-Handling-Spec-34b6a5d7f9f681e78003c443f227493c)
 
+## [7.1.0] - 2026-MM-DD
+
+### Added (CHA-2956 connection pooling)
+
+- New runtime dependency: `faraday-net_http_persistent ~> 2.3` + `net-http-persistent ~> 4.0`.
+  Default Faraday adapter switched from `Faraday.default_adapter` (plain `Net::HTTP`,
+  no pool) to `:net_http_persistent` (pooled). Matches legacy `stream-chat-ruby`.
+- New constructor kwargs on `GetStreamRuby.manual` / `Configuration`:
+    * `max_conns_per_host:` — default `5`
+    * `idle_timeout:` — default `55` (seconds)
+    * `connect_timeout:` — default `10` (seconds)
+    * `request_timeout:` — default `30` (seconds)
+    * `http_client:` — escape hatch (`Faraday::Connection`); when set, the 4
+      knobs above are ignored.
+- Per-call `request_timeout:` kwarg on `Client#make_request` for one-off
+  overrides without rebuilding the client.
+- One INFO log on `Client.new` listing the effective pool config + escape-hatch
+  flag (§8 transparency requirement).
+
+### Changed
+
+- Default adapter is now `:net_http_persistent`; long-lived processes hold up
+  to 5 idle TCP connections per upstream host until they age out at 55s.
+- The `Connection: keep-alive` request header is no longer emitted on the
+  default path (`net_http_persistent` keeps connections alive natively). Still
+  emitted when the user opts into a custom `faraday_adapter` with
+  `connection_keep_alive: true`.
+
+### Backwards compatibility
+
+- The `timeout:` kwarg remains as an alias for `request_timeout:`.
+- The `faraday_adapter` kwarg remains as an alternate escape hatch — when set,
+  `pool_size`/`idle_timeout` are NOT applied (those are
+  `net_http_persistent`-specific).
+
+See the [Connection Pooling Spec](https://www.notion.so/stream-wiki/Server-Side-SDK-Connection-Pooling-Spec-3496a5d7f9f680749b8be9ee238ae108).
+
 ## [6.0.0] - 2026-04-17
 
 ### major^2 changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
   invalid base64 in a queue body, and malformed SNS envelopes. Distinguish failure modes
   via the message substring or `cause` chain rather than the class.
 - New instance methods on `GetStreamRuby::Client`: `verify_signature(body, signature)` and
-  `verify_and_parse_webhook(body, signature)` — drop the `api_secret` parameter in favor
+  `verify_and_parse_webhook(body, signature)` that drop the `api_secret` parameter in favor
   of the client's stored secret. Dual API: module-level methods remain available.
 - New instance methods on `GetStreamRuby::Client`: `parse_sqs(message_body)` and
   `parse_sns(notification_body)` (no signature; AWS IAM).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,6 @@
   (was `StreamChat::*Event`, which raised `NameError` at runtime). `parse_event`
   resolves known event types correctly.
 
-[Spec](https://www.notion.so/stream-wiki/Server-Side-SDK-Webhook-Handling-Spec-34b6a5d7f9f681e78003c443f227493c)
-
 ## [7.1.0] - 2026-MM-DD
 
 ### Added (CHA-2956 connection pooling)
@@ -52,7 +50,7 @@
 - Per-call `request_timeout:` kwarg on `Client#make_request` for one-off
   overrides without rebuilding the client.
 - One INFO log on `Client.new` listing the effective pool config + escape-hatch
-  flag (§8 transparency requirement).
+  flag.
 
 ### Changed
 
@@ -66,11 +64,9 @@
 ### Backwards compatibility
 
 - The `timeout:` kwarg remains as an alias for `request_timeout:`.
-- The `faraday_adapter` kwarg remains as an alternate escape hatch — when set,
+- The `faraday_adapter` kwarg remains as an alternate escape hatch. When set,
   `pool_size`/`idle_timeout` are NOT applied (those are
   `net_http_persistent`-specific).
-
-See the [Connection Pooling Spec](https://www.notion.so/stream-wiki/Server-Side-SDK-Connection-Pooling-Spec-3496a5d7f9f680749b8be9ee238ae108).
 
 ## [6.0.0] - 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,36 +37,25 @@
 
 ### Added (CHA-2956 connection pooling)
 
-- New runtime dependency: `faraday-net_http_persistent ~> 2.3` + `net-http-persistent ~> 4.0`.
-  Default Faraday adapter switched from `Faraday.default_adapter` (plain `Net::HTTP`,
-  no pool) to `:net_http_persistent` (pooled). Matches legacy `stream-chat-ruby`.
+- New runtime dependency: `faraday-net_http_persistent ~> 2.3` + `net-http-persistent ~> 4.0`. Default Faraday adapter switched from `Faraday.default_adapter` (plain `Net::HTTP`, no pool) to `:net_http_persistent` (pooled). Matches legacy `stream-chat-ruby`.
 - New constructor kwargs on `GetStreamRuby.manual` / `Configuration`:
-    * `max_conns_per_host:` — default `5`
-    * `idle_timeout:` — default `55` (seconds)
-    * `connect_timeout:` — default `10` (seconds)
-    * `request_timeout:` — default `30` (seconds)
-    * `http_client:` — escape hatch (`Faraday::Connection`); when set, the 4
-      knobs above are ignored.
-- Per-call `request_timeout:` kwarg on `Client#make_request` for one-off
-  overrides without rebuilding the client.
-- One INFO log on `Client.new` listing the effective pool config + escape-hatch
-  flag.
+    * `max_conns_per_host:` default `5`
+    * `idle_timeout:` default `55` (seconds)
+    * `connect_timeout:` default `10` (seconds)
+    * `request_timeout:` default `30` (seconds)
+    * `http_client:` escape hatch (`Faraday::Connection`); when set, the 4 knobs above are ignored.
+- Per-call `request_timeout:` kwarg on `Client#make_request` for one-off overrides without rebuilding the client.
+- One INFO log on `Client.new` listing the effective pool config + escape-hatch flag.
 
 ### Changed
 
-- Default adapter is now `:net_http_persistent`; long-lived processes hold up
-  to 5 idle TCP connections per upstream host until they age out at 55s.
-- The `Connection: keep-alive` request header is no longer emitted on the
-  default path (`net_http_persistent` keeps connections alive natively). Still
-  emitted when the user opts into a custom `faraday_adapter` with
-  `connection_keep_alive: true`.
+- Default adapter is now `:net_http_persistent`; long-lived processes hold up to 5 idle TCP connections per upstream host until they age out at 55s.
+- The `Connection: keep-alive` request header is no longer emitted on the default path (`net_http_persistent` keeps connections alive natively). Still emitted when the user opts into a custom `faraday_adapter` with `connection_keep_alive: true`.
 
 ### Backwards compatibility
 
 - The `timeout:` kwarg remains as an alias for `request_timeout:`.
-- The `faraday_adapter` kwarg remains as an alternate escape hatch. When set,
-  `pool_size`/`idle_timeout` are NOT applied (those are
-  `net_http_persistent`-specific).
+- The `faraday_adapter` kwarg remains as an alternate escape hatch. When set, `pool_size`/`idle_timeout` are NOT applied (those are `net_http_persistent`-specific).
 
 ## [6.0.0] - 2026-04-17
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 gemspec name: 'getstream-ruby'
 
-# Pin transitive dep: connection_pool 3.x requires Ruby >= 3.4.
+# Pin transitive dep: connection_pool 3.x requires Ruby >= 3.2.
 # net-http-persistent accepts 2.x (>= 2.2.4, < 4), and CI runs Ruby 3.1.
 gem 'connection_pool', '< 3.0'
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,10 @@ source 'https://rubygems.org'
 
 gemspec name: 'getstream-ruby'
 
+# Pin transitive dep: connection_pool 3.x requires Ruby >= 3.4.
+# net-http-persistent accepts 2.x (>= 2.2.4, < 4), and CI runs Ruby 3.1.
+gem 'connection_pool', '< 3.0'
+
 group :development, :test do
 
   gem 'bundler-audit', '~> 0.9'

--- a/getstream-ruby.gemspec
+++ b/getstream-ruby.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.6.0'
 
   spec.add_dependency 'dotenv', '>= 2.0'
-  spec.add_dependency 'faraday', '~> 2.0'
+  spec.add_dependency 'faraday', '~> 2.5'
   spec.add_dependency 'faraday-gzip', '~> 3.0'
   spec.add_dependency 'faraday-multipart', '~> 1.0'
   spec.add_dependency 'faraday-net_http_persistent', '~> 2.3'

--- a/getstream-ruby.gemspec
+++ b/getstream-ruby.gemspec
@@ -22,9 +22,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '~> 2.0'
   spec.add_dependency 'faraday-gzip', '~> 3.0'
   spec.add_dependency 'faraday-multipart', '~> 1.0'
+  spec.add_dependency 'faraday-net_http_persistent', '~> 2.3'
   spec.add_dependency 'faraday-retry', '~> 2.0'
   spec.add_dependency 'json', '~> 2.0'
   spec.add_dependency 'jwt', '~> 2.0'
+  spec.add_dependency 'net-http-persistent', '~> 4.0'
 
   # spec.metadata['rubygems_mfa_required'] = 'true'
 

--- a/lib/getstream_ruby/client.rb
+++ b/lib/getstream_ruby/client.rb
@@ -39,6 +39,7 @@ module GetStreamRuby
 
       @configuration.validate!
       @connection = build_connection
+      log_pool_config
     end
 
     def feed_resource
@@ -339,6 +340,29 @@ module GetStreamRuby
       else
         'application/octet-stream'
       end
+    end
+
+    def log_pool_config
+      logger = @configuration.logger || Logger.new($stdout).tap { |l| l.level = Logger::INFO }
+      flag = @configuration.http_client ? 'user_http_client=true' : 'user_http_client=false'
+      adapter_label = if @configuration.http_client
+                        'user-supplied'
+                      elsif @configuration.faraday_adapter
+                        @configuration.faraday_adapter.to_s
+                      else
+                        'default'
+                      end
+      logger.info(
+        format(
+          'connection pool: max_conns_per_host=%<m>d idle_timeout=%<i>d connect_timeout=%<c>d request_timeout=%<r>d %<flag>s faraday_adapter=%<a>s',
+          m: @configuration.max_conns_per_host,
+          i: @configuration.idle_timeout,
+          c: @configuration.connect_timeout,
+          r: @configuration.request_timeout,
+          flag: flag,
+          a: adapter_label,
+        ),
+      )
     end
 
   end

--- a/lib/getstream_ruby/client.rb
+++ b/lib/getstream_ruby/client.rb
@@ -4,6 +4,8 @@ require 'faraday'
 require 'faraday/gzip'
 require 'faraday/retry'
 require 'faraday/multipart'
+require 'faraday/net_http_persistent'
+require 'logger'
 require 'json'
 require 'jwt'
 require_relative 'generated/base_model'
@@ -168,6 +170,10 @@ module GetStreamRuby
     end
 
     def build_connection
+      # §7 escape hatch #1: user supplied a fully-built Faraday::Connection.
+      # Use it as-is; none of the 5 knobs apply.
+      return @configuration.http_client if @configuration.http_client
+
       Faraday.new(url: @configuration.base_url) do |conn|
 
         conn.request :multipart
@@ -180,20 +186,40 @@ module GetStreamRuby
         conn.response :json, content_type: /\bjson$/
         # :gzip must come after :json (Faraday runs response middleware in reverse).
         conn.request :gzip
-        conn.headers['Connection'] = 'keep-alive' if @configuration.connection_keep_alive
         configure_adapter(conn)
-        conn.options.timeout = @configuration.timeout
+
+        conn.options.timeout = @configuration.request_timeout
+        conn.options.open_timeout = @configuration.connect_timeout
 
       end
     end
 
     def configure_adapter(connection)
-      adapter = @configuration.faraday_adapter || Faraday.default_adapter
-      adapter_options = @configuration.faraday_adapter_options || {}
-      connection.adapter(adapter, **adapter_options)
+      # §7 escape hatch #2: custom adapter symbol. Use it with the user's
+      # adapter_options; do NOT apply pool_size/idle_timeout (those are
+      # net_http_persistent-specific).
+      if @configuration.faraday_adapter
+        adapter = @configuration.faraday_adapter
+        adapter_options = @configuration.faraday_adapter_options || {}
+        # Header-based keep-alive only on the custom-adapter path. net_http_persistent
+        # (default) keeps connections alive natively without any HTTP header.
+        connection.headers['Connection'] = 'keep-alive' if @configuration.connection_keep_alive
+        connection.adapter(adapter, **adapter_options)
+        return
+      end
+
+      # Default: net_http_persistent with the 5-knob spec config.
+      # §5 invariant 4 — never set Connection: close; net_http_persistent keeps
+      # connections alive natively.
+      idle = @configuration.idle_timeout
+      connection.adapter :net_http_persistent, pool_size: @configuration.max_conns_per_host do |http|
+
+        http.idle_timeout = idle
+
+      end
     rescue Faraday::Error, ArgumentError => e
       @configuration.logger&.warn(
-        "Falling back to #{Faraday.default_adapter}: could not use adapter #{adapter} (#{e.message})",
+        "Falling back to #{Faraday.default_adapter}: could not configure net_http_persistent (#{e.message})",
       )
       connection.adapter Faraday.default_adapter
     end

--- a/lib/getstream_ruby/client.rb
+++ b/lib/getstream_ruby/client.rb
@@ -133,7 +133,7 @@ module GetStreamRuby
       request(:post, path, body)
     end
 
-    def make_request(method, path, query_params: nil, body: nil)
+    def make_request(method, path, query_params: nil, body: nil, request_timeout: nil)
       # Handle query parameters
       if query_params && !query_params.empty?
         query_string = query_params.map { |k, v| "#{k}=#{v}" }.join('&')
@@ -141,12 +141,12 @@ module GetStreamRuby
       end
 
       # Make the request
-      request(method, path, body)
+      request(method, path, body, request_timeout: request_timeout)
     end
 
     private
 
-    def request(method, path, data = {})
+    def request(method, path, data = {}, request_timeout: nil)
       # Add API key to query parameters
       query_params = { api_key: @configuration.api_key }
 
@@ -161,6 +161,7 @@ module GetStreamRuby
         req.headers['stream-auth-type'] = 'jwt'
         req.headers['X-Stream-Client'] = user_agent
         req.body = data.to_json
+        req.options.timeout = request_timeout if request_timeout
 
       end
 

--- a/lib/getstream_ruby/client.rb
+++ b/lib/getstream_ruby/client.rb
@@ -219,10 +219,11 @@ module GetStreamRuby
 
       end
     rescue Faraday::Error, ArgumentError => e
-      @configuration.logger&.warn(
-        "Falling back to #{Faraday.default_adapter}: could not configure net_http_persistent (#{e.message})",
-      )
+      # A fallback silently disables pooling, so always WARN (never swallow).
+      @configuration.warn_pool_fallback(Faraday.default_adapter, e)
       connection.adapter Faraday.default_adapter
+      # Record the adapter actually built so the INFO log reports it accurately.
+      @configuration.effective_adapter = Faraday.default_adapter.to_s
     end
 
     def generate_auth_header

--- a/lib/getstream_ruby/client.rb
+++ b/lib/getstream_ruby/client.rb
@@ -172,7 +172,7 @@ module GetStreamRuby
     end
 
     def build_connection
-      # §7 escape hatch #1: user supplied a fully-built Faraday::Connection.
+      # Escape hatch #1: user supplied a fully-built Faraday::Connection.
       # Use it as-is; none of the 5 knobs apply.
       return @configuration.http_client if @configuration.http_client
 
@@ -197,7 +197,7 @@ module GetStreamRuby
     end
 
     def configure_adapter(connection)
-      # §7 escape hatch #2: custom adapter symbol. Use it with the user's
+      # Escape hatch #2: custom adapter symbol. Use it with the user's
       # adapter_options; do NOT apply pool_size/idle_timeout (those are
       # net_http_persistent-specific).
       if @configuration.faraday_adapter
@@ -210,8 +210,8 @@ module GetStreamRuby
         return
       end
 
-      # Default: net_http_persistent with the 5-knob spec config.
-      # §5 invariant 4 — never set Connection: close; net_http_persistent keeps
+      # Default: net_http_persistent with the 5-knob config.
+      # Never set Connection: close; net_http_persistent keeps
       # connections alive natively.
       idle = @configuration.idle_timeout
       connection.adapter :net_http_persistent, pool_size: @configuration.max_conns_per_host do |http|

--- a/lib/getstream_ruby/client.rb
+++ b/lib/getstream_ruby/client.rb
@@ -203,16 +203,15 @@ module GetStreamRuby
       if @configuration.faraday_adapter
         adapter = @configuration.faraday_adapter
         adapter_options = @configuration.faraday_adapter_options || {}
-        # Header-based keep-alive only on the custom-adapter path. net_http_persistent
-        # (default) keeps connections alive natively without any HTTP header.
+        # Header-based keep-alive only on the custom-adapter path.
+        # net_http_persistent (default) keeps connections alive natively without any HTTP header.
         connection.headers['Connection'] = 'keep-alive' if @configuration.connection_keep_alive
         connection.adapter(adapter, **adapter_options)
         return
       end
 
       # Default: net_http_persistent with the 5-knob config.
-      # Never set Connection: close; net_http_persistent keeps
-      # connections alive natively.
+      # Never set Connection: close; net_http_persistent keeps connections alive natively.
       idle = @configuration.idle_timeout
       connection.adapter :net_http_persistent, pool_size: @configuration.max_conns_per_host do |http|
 

--- a/lib/getstream_ruby/client.rb
+++ b/lib/getstream_ruby/client.rb
@@ -39,7 +39,7 @@ module GetStreamRuby
 
       @configuration.validate!
       @connection = build_connection
-      log_pool_config
+      @configuration.log_pool_config_to(@configuration.logger)
     end
 
     def feed_resource
@@ -340,29 +340,6 @@ module GetStreamRuby
       else
         'application/octet-stream'
       end
-    end
-
-    def log_pool_config
-      logger = @configuration.logger || Logger.new($stdout).tap { |l| l.level = Logger::INFO }
-      flag = @configuration.http_client ? 'user_http_client=true' : 'user_http_client=false'
-      adapter_label = if @configuration.http_client
-                        'user-supplied'
-                      elsif @configuration.faraday_adapter
-                        @configuration.faraday_adapter.to_s
-                      else
-                        'default'
-                      end
-      logger.info(
-        format(
-          'connection pool: max_conns_per_host=%<m>d idle_timeout=%<i>d connect_timeout=%<c>d request_timeout=%<r>d %<flag>s faraday_adapter=%<a>s',
-          m: @configuration.max_conns_per_host,
-          i: @configuration.idle_timeout,
-          c: @configuration.connect_timeout,
-          r: @configuration.request_timeout,
-          flag: flag,
-          a: adapter_label,
-        ),
-      )
     end
 
   end

--- a/lib/getstream_ruby/configuration.rb
+++ b/lib/getstream_ruby/configuration.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'logger'
+
 module GetStreamRuby
 
   class Configuration
@@ -9,53 +11,16 @@ module GetStreamRuby
                   :request_timeout, :http_client
 
     def initialize(api_key: nil, api_secret: nil, use_env: true, **options)
-      base_url = options[:base_url]
-      timeout = options[:timeout]
-      request_timeout = options[:request_timeout]
-      max_conns_per_host = options[:max_conns_per_host]
-      idle_timeout = options[:idle_timeout]
-      connect_timeout = options[:connect_timeout]
-      http_client = options[:http_client]
       http_options = options[:http_options] || {}
-      faraday_adapter = options[:faraday_adapter] || http_options[:faraday_adapter]
-      faraday_adapter_options = options[:faraday_adapter_options] || http_options[:faraday_adapter_options]
-      connection_keep_alive = if options.key?(:connection_keep_alive)
-                                options[:connection_keep_alive]
-                              else
-                                http_options[:connection_keep_alive]
-                              end
 
-      if use_env
-        @api_key = api_key || ENV.fetch('STREAM_API_KEY', nil)
-        @api_secret = api_secret || ENV.fetch('STREAM_API_SECRET', nil)
-        @base_url = base_url || ENV['STREAM_BASE_URL'] || 'https://chat.stream-io-api.com'
-        env_request_timeout = ENV['STREAM_REQUEST_TIMEOUT'] || ENV['STREAM_TIMEOUT']
-        @request_timeout = (request_timeout || timeout || env_request_timeout || 30).to_i
-        @max_conns_per_host = (max_conns_per_host || ENV['STREAM_MAX_CONNS_PER_HOST'] || 5).to_i
-        @idle_timeout = (idle_timeout || ENV['STREAM_IDLE_TIMEOUT'] || 55).to_i
-        @connect_timeout = (connect_timeout || ENV['STREAM_CONNECT_TIMEOUT'] || 10).to_i
-      else
-        # Manual configuration only - no environment variables
-        @api_key = api_key
-        @api_secret = api_secret
-        @base_url = base_url || 'https://chat.stream-io-api.com'
-        @request_timeout = (request_timeout || timeout || 30).to_i
-        @max_conns_per_host = (max_conns_per_host || 5).to_i
-        @idle_timeout = (idle_timeout || 55).to_i
-        @connect_timeout = (connect_timeout || 10).to_i
-      end
+      assign_credentials_and_url(api_key, api_secret, options[:base_url], use_env: use_env)
+      assign_timeouts_and_pool(options, use_env: use_env)
+      assign_adapter(options, http_options)
+      assign_keep_alive(options, http_options)
 
       # Keep @timeout in sync with @request_timeout for backwards compatibility.
       @timeout = @request_timeout
-
-      @http_client = http_client
-      @faraday_adapter = (faraday_adapter || ENV.fetch('STREAM_FARADAY_ADAPTER', nil))&.to_sym
-      @faraday_adapter_options = faraday_adapter_options || default_adapter_options
-      @connection_keep_alive = if connection_keep_alive.nil?
-                                 ENV.fetch('STREAM_CONNECTION_KEEP_ALIVE', 'true') == 'true'
-                               else
-                                 connection_keep_alive
-                               end
+      @http_client = options[:http_client]
       @logger = options[:logger]
     end
 
@@ -86,6 +51,30 @@ module GetStreamRuby
       )
     end
 
+    # Emit a single INFO line listing the 5 effective pool knobs plus the
+    # active escape hatch (CHA-2956 §8 transparency requirement). If no logger
+    # is supplied, a default $stdout INFO logger is used.
+    def log_pool_config_to(logger)
+      logger ||= Logger.new($stdout).tap { |l| l.level = Logger::INFO }
+      flag = @http_client ? 'user_http_client=true' : 'user_http_client=false'
+      adapter_label = if @http_client
+                        'user-supplied'
+                      elsif @faraday_adapter
+                        @faraday_adapter.to_s
+                      else
+                        'default'
+                      end
+      fmt = 'connection pool: max_conns_per_host=%<m>d idle_timeout=%<i>d ' \
+            'connect_timeout=%<c>d request_timeout=%<r>d %<flag>s faraday_adapter=%<a>s'
+      logger.info(
+        format(
+          fmt,
+          m: @max_conns_per_host, i: @idle_timeout, c: @connect_timeout,
+          r: @request_timeout, flag: flag, a: adapter_label
+        ),
+      )
+    end
+
     # Class method to create configuration with overrides
     def self.with_overrides(overrides = {})
       new(**overrides)
@@ -111,6 +100,59 @@ module GetStreamRuby
 
     def default_adapter_options
       {}
+    end
+
+    def assign_credentials_and_url(api_key, api_secret, base_url, use_env:)
+      if use_env
+        @api_key = api_key || ENV.fetch('STREAM_API_KEY', nil)
+        @api_secret = api_secret || ENV.fetch('STREAM_API_SECRET', nil)
+        @base_url = base_url || ENV.fetch('STREAM_BASE_URL', nil) || 'https://chat.stream-io-api.com'
+      else
+        @api_key = api_key
+        @api_secret = api_secret
+        @base_url = base_url || 'https://chat.stream-io-api.com'
+      end
+    end
+
+    def assign_timeouts_and_pool(options, use_env:)
+      timeout = options[:timeout]
+      request_timeout = options[:request_timeout]
+      max_conns_per_host = options[:max_conns_per_host]
+      idle_timeout = options[:idle_timeout]
+      connect_timeout = options[:connect_timeout]
+
+      if use_env
+        env_request_timeout = ENV.fetch('STREAM_REQUEST_TIMEOUT', nil) || ENV.fetch('STREAM_TIMEOUT', nil)
+        @request_timeout = (request_timeout || timeout || env_request_timeout || 30).to_i
+        @max_conns_per_host = (max_conns_per_host || ENV.fetch('STREAM_MAX_CONNS_PER_HOST', nil) || 5).to_i
+        @idle_timeout = (idle_timeout || ENV.fetch('STREAM_IDLE_TIMEOUT', nil) || 55).to_i
+        @connect_timeout = (connect_timeout || ENV.fetch('STREAM_CONNECT_TIMEOUT', nil) || 10).to_i
+      else
+        @request_timeout = (request_timeout || timeout || 30).to_i
+        @max_conns_per_host = (max_conns_per_host || 5).to_i
+        @idle_timeout = (idle_timeout || 55).to_i
+        @connect_timeout = (connect_timeout || 10).to_i
+      end
+    end
+
+    def assign_adapter(options, http_options)
+      faraday_adapter = options[:faraday_adapter] || http_options[:faraday_adapter]
+      faraday_adapter_options = options[:faraday_adapter_options] || http_options[:faraday_adapter_options]
+      @faraday_adapter = (faraday_adapter || ENV.fetch('STREAM_FARADAY_ADAPTER', nil))&.to_sym
+      @faraday_adapter_options = faraday_adapter_options || default_adapter_options
+    end
+
+    def assign_keep_alive(options, http_options)
+      connection_keep_alive = if options.key?(:connection_keep_alive)
+                                options[:connection_keep_alive]
+                              else
+                                http_options[:connection_keep_alive]
+                              end
+      @connection_keep_alive = if connection_keep_alive.nil?
+                                 ENV.fetch('STREAM_CONNECTION_KEEP_ALIVE', 'true') == 'true'
+                               else
+                                 connection_keep_alive
+                               end
     end
 
   end

--- a/lib/getstream_ruby/configuration.rb
+++ b/lib/getstream_ruby/configuration.rb
@@ -51,9 +51,8 @@ module GetStreamRuby
       )
     end
 
-    # Emit a single INFO line listing the 5 effective pool knobs plus the
-    # active escape hatch (CHA-2956). If no logger
-    # is supplied, a default $stdout INFO logger is used.
+    # Emit a single INFO line listing the 5 effective pool knobs plus the active escape hatch (CHA-2956).
+    # If no logger is supplied, a default $stdout INFO logger is used.
     def log_pool_config_to(logger)
       logger ||= Logger.new($stdout).tap { |l| l.level = Logger::INFO }
       flag = @http_client ? 'user_http_client=true' : 'user_http_client=false'

--- a/lib/getstream_ruby/configuration.rb
+++ b/lib/getstream_ruby/configuration.rb
@@ -8,7 +8,7 @@ module GetStreamRuby
 
     attr_accessor :api_key, :api_secret, :base_url, :timeout, :logger, :faraday_adapter, :faraday_adapter_options,
                   :connection_keep_alive, :max_conns_per_host, :idle_timeout, :connect_timeout,
-                  :request_timeout, :http_client
+                  :request_timeout, :http_client, :effective_adapter
 
     def initialize(api_key: nil, api_secret: nil, use_env: true, **options)
       http_options = options[:http_options] || {}
@@ -53,11 +53,16 @@ module GetStreamRuby
 
     # Emit a single INFO line listing the 5 effective pool knobs plus the active escape hatch (CHA-2956).
     # If no logger is supplied, a default $stdout INFO logger is used.
+    # The faraday_adapter label reflects the adapter actually built
+    # (effective_adapter, set by Client#configure_adapter) so a silent fallback
+    # to the default adapter is never misreported as the requested adapter.
     def log_pool_config_to(logger)
       logger ||= Logger.new($stdout).tap { |l| l.level = Logger::INFO }
       flag = @http_client ? 'user_http_client=true' : 'user_http_client=false'
       adapter_label = if @http_client
                         'user-supplied'
+                      elsif @effective_adapter
+                        @effective_adapter
                       elsif @faraday_adapter
                         @faraday_adapter.to_s
                       else
@@ -71,6 +76,17 @@ module GetStreamRuby
           m: @max_conns_per_host, i: @idle_timeout, c: @connect_timeout,
           r: @request_timeout, flag: flag, a: adapter_label
         ),
+      )
+    end
+
+    # Emit a WARNING that the requested adapter could not be built and pooling
+    # is disabled (CHA-2956). A fallback must never be silent, so when no logger
+    # is configured this uses a default $stdout logger, exactly like
+    # log_pool_config_to.
+    def warn_pool_fallback(fallback_adapter, error)
+      warn_logger = @logger || Logger.new($stdout).tap { |l| l.level = Logger::WARN }
+      warn_logger.warn(
+        "Falling back to #{fallback_adapter}: could not configure net_http_persistent (#{error.message})",
       )
     end
 

--- a/lib/getstream_ruby/configuration.rb
+++ b/lib/getstream_ruby/configuration.rb
@@ -5,11 +5,17 @@ module GetStreamRuby
   class Configuration
 
     attr_accessor :api_key, :api_secret, :base_url, :timeout, :logger, :faraday_adapter, :faraday_adapter_options,
-                  :connection_keep_alive
+                  :connection_keep_alive, :max_conns_per_host, :idle_timeout, :connect_timeout,
+                  :request_timeout, :http_client
 
     def initialize(api_key: nil, api_secret: nil, use_env: true, **options)
       base_url = options[:base_url]
       timeout = options[:timeout]
+      request_timeout = options[:request_timeout]
+      max_conns_per_host = options[:max_conns_per_host]
+      idle_timeout = options[:idle_timeout]
+      connect_timeout = options[:connect_timeout]
+      http_client = options[:http_client]
       http_options = options[:http_options] || {}
       faraday_adapter = options[:faraday_adapter] || http_options[:faraday_adapter]
       faraday_adapter_options = options[:faraday_adapter_options] || http_options[:faraday_adapter_options]
@@ -23,15 +29,26 @@ module GetStreamRuby
         @api_key = api_key || ENV.fetch('STREAM_API_KEY', nil)
         @api_secret = api_secret || ENV.fetch('STREAM_API_SECRET', nil)
         @base_url = base_url || ENV['STREAM_BASE_URL'] || 'https://chat.stream-io-api.com'
-        @timeout = timeout || (ENV['STREAM_TIMEOUT'] || 30).to_i
+        env_request_timeout = ENV['STREAM_REQUEST_TIMEOUT'] || ENV['STREAM_TIMEOUT']
+        @request_timeout = (request_timeout || timeout || env_request_timeout || 30).to_i
+        @max_conns_per_host = (max_conns_per_host || ENV['STREAM_MAX_CONNS_PER_HOST'] || 5).to_i
+        @idle_timeout = (idle_timeout || ENV['STREAM_IDLE_TIMEOUT'] || 55).to_i
+        @connect_timeout = (connect_timeout || ENV['STREAM_CONNECT_TIMEOUT'] || 10).to_i
       else
         # Manual configuration only - no environment variables
         @api_key = api_key
         @api_secret = api_secret
         @base_url = base_url || 'https://chat.stream-io-api.com'
-        @timeout = timeout || 30
+        @request_timeout = (request_timeout || timeout || 30).to_i
+        @max_conns_per_host = (max_conns_per_host || 5).to_i
+        @idle_timeout = (idle_timeout || 55).to_i
+        @connect_timeout = (connect_timeout || 10).to_i
       end
 
+      # Keep @timeout in sync with @request_timeout for backwards compatibility.
+      @timeout = @request_timeout
+
+      @http_client = http_client
       @faraday_adapter = (faraday_adapter || ENV.fetch('STREAM_FARADAY_ADAPTER', nil))&.to_sym
       @faraday_adapter_options = faraday_adapter_options || default_adapter_options
       @connection_keep_alive = if connection_keep_alive.nil?
@@ -39,7 +56,7 @@ module GetStreamRuby
                                else
                                  connection_keep_alive
                                end
-      @logger = nil
+      @logger = options[:logger]
     end
 
     def valid?
@@ -57,9 +74,15 @@ module GetStreamRuby
         api_secret: @api_secret,
         base_url: @base_url,
         timeout: @timeout,
+        request_timeout: @request_timeout,
+        max_conns_per_host: @max_conns_per_host,
+        idle_timeout: @idle_timeout,
+        connect_timeout: @connect_timeout,
+        http_client: @http_client,
         faraday_adapter: @faraday_adapter,
         faraday_adapter_options: @faraday_adapter_options.dup,
         connection_keep_alive: @connection_keep_alive,
+        logger: @logger,
       )
     end
 

--- a/lib/getstream_ruby/configuration.rb
+++ b/lib/getstream_ruby/configuration.rb
@@ -52,7 +52,7 @@ module GetStreamRuby
     end
 
     # Emit a single INFO line listing the 5 effective pool knobs plus the
-    # active escape hatch (CHA-2956 §8 transparency requirement). If no logger
+    # active escape hatch (CHA-2956). If no logger
     # is supplied, a default $stdout INFO logger is used.
     def log_pool_config_to(logger)
       logger ||= Logger.new($stdout).tap { |l| l.level = Logger::INFO }

--- a/lib/getstream_ruby/generated/webhook.rb
+++ b/lib/getstream_ruby/generated/webhook.rb
@@ -817,7 +817,7 @@ module StreamChat
     # detection decides whether to decompress.
     #
     # {parse_sqs} sits on top of this and works transparently for both wire
-    # formats — no caller code change, no flag, no header.
+    # formats: no caller code change, no flag, no header.
     #
     # @param message_body [String]
     # @return [String]
@@ -829,7 +829,7 @@ module StreamChat
         begin
           Base64.strict_decode64(message_body)
         rescue ArgumentError
-          # Not base64 — treat input as raw bytes (uncompressed wire format).
+          # Not base64, so treat input as raw bytes (uncompressed wire format).
           message_body.dup.force_encoding(Encoding::ASCII_8BIT)
         end
       gunzip_payload(decoded)
@@ -840,7 +840,7 @@ module StreamChat
     # pre-extracted Message string flows through.
     #
     # Heuristic: try to JSON-parse the input. If it yields a Hash with a
-    # String +Message+ field, that's the envelope shape — return the Message.
+    # String +Message+ field, that's the envelope shape; return the Message.
     # Otherwise the input is presumed to BE the pre-extracted Message
     # (base64-encoded bytes are not valid JSON, so this falls through cleanly).
     def self.unwrap_sns_notification_body(body)

--- a/lib/getstream_ruby/version.rb
+++ b/lib/getstream_ruby/version.rb
@@ -2,6 +2,6 @@
 
 module GetStreamRuby
 
-  VERSION = '7.0.0'
+  VERSION = '7.1.0'
 
 end

--- a/spec/connection_pooling_spec.rb
+++ b/spec/connection_pooling_spec.rb
@@ -6,6 +6,24 @@ require 'faraday/net_http_persistent'
 # CHA-2956 connection pooling spec.
 RSpec.describe 'CHA-2956 connection pooling' do
 
+  # Capture the args/kwargs of the last `conn.adapter` call made while the
+  # block runs. Intercepts the public Faraday::RackBuilder#adapter API (the
+  # same call the client makes) rather than the handler's internal @args
+  # ivar, whose layout changed between Faraday 2.8 (kwargs in @args) and 2.9+
+  # (kwargs in a separate @kwargs), which made the old introspection nil in CI.
+  def capture_adapter_call
+    captured = { args: [], kwargs: {} }
+    allow_any_instance_of(Faraday::RackBuilder).to receive(:adapter).and_wrap_original do |orig, *args, **kwargs, &blk|
+
+      captured[:args] = args
+      captured[:kwargs] = kwargs
+      orig.call(*args, **kwargs, &blk)
+
+    end
+    yield
+    captured
+  end
+
   describe 'defaults' do
 
     let(:client) { GetStreamRuby.manual(api_key: 'k', api_secret: 's') }
@@ -27,9 +45,9 @@ RSpec.describe 'CHA-2956 connection pooling' do
 
     it 'passes pool_size=5 to the net_http_persistent adapter' do
 
-      handler = client.instance_variable_get(:@connection).builder.adapter
-      kwargs = handler.instance_variable_get(:@args).last
-      expect(kwargs).to include(pool_size: 5)
+      captured = capture_adapter_call { GetStreamRuby.manual(api_key: 'k', api_secret: 's') }
+      expect(captured[:args].first).to eq(:net_http_persistent)
+      expect(captured[:kwargs]).to include(pool_size: 5)
 
     end
 
@@ -39,9 +57,12 @@ RSpec.describe 'CHA-2956 connection pooling' do
 
     it 'honors max_conns_per_host:' do
 
-      client = GetStreamRuby.manual(api_key: 'k', api_secret: 's', max_conns_per_host: 17)
-      handler = client.instance_variable_get(:@connection).builder.adapter
-      expect(handler.instance_variable_get(:@args).last).to include(pool_size: 17)
+      captured = capture_adapter_call do
+
+        GetStreamRuby.manual(api_key: 'k', api_secret: 's', max_conns_per_host: 17)
+
+      end
+      expect(captured[:kwargs]).to include(pool_size: 17)
 
     end
 
@@ -136,17 +157,18 @@ RSpec.describe 'CHA-2956 connection pooling' do
 
     it 'uses the custom adapter symbol and does NOT apply pool_size' do
 
-      client = GetStreamRuby.manual(
-        api_key: 'k', api_secret: 's',
-        faraday_adapter: :net_http,
-        max_conns_per_host: 17 # MUST be ignored
-      )
+      captured = capture_adapter_call do
 
-      handler = client.instance_variable_get(:@connection).builder.adapter
-      expect(handler.klass).to eq(Faraday::Adapter::NetHttp)
-      kwargs = handler.instance_variable_get(:@args).last
-      kwargs = {} unless kwargs.is_a?(Hash)
-      expect(kwargs).not_to include(pool_size: 17)
+        GetStreamRuby.manual(
+          api_key: 'k', api_secret: 's',
+          faraday_adapter: :net_http,
+          max_conns_per_host: 17 # MUST be ignored
+        )
+
+      end
+
+      expect(captured[:args].first).to eq(:net_http)
+      expect(captured[:kwargs]).not_to include(pool_size: 17)
 
     end
 

--- a/spec/connection_pooling_spec.rb
+++ b/spec/connection_pooling_spec.rb
@@ -174,6 +174,50 @@ RSpec.describe 'CHA-2956 connection pooling' do
 
   end
 
+  describe 'adapter fallback' do
+
+    # A bogus adapter symbol forces configure_adapter into its rescue, which
+    # falls back to Faraday.default_adapter and disables pooling.
+    let(:bogus) { :bogus_xyz_adapter }
+
+    it 'warns via a $stdout logger when no logger is configured (never silent)' do
+
+      build = -> { GetStreamRuby.manual(api_key: 'k', api_secret: 's', faraday_adapter: bogus) }
+      expect(&build).to output(/Falling back to .*could not configure net_http_persistent/).to_stdout
+
+    end
+
+    it 'warns on the configured logger when one is supplied' do
+
+      log_io = StringIO.new
+      logger = Logger.new(log_io).tap { |l| l.level = Logger::WARN }
+      GetStreamRuby.manual(api_key: 'k', api_secret: 's', faraday_adapter: bogus, logger: logger)
+      expect(log_io.string).to include('WARN').and include('Falling back to')
+
+    end
+
+    it 'builds the default adapter, not the requested-but-failed one' do
+
+      client = GetStreamRuby.manual(api_key: 'k', api_secret: 's', faraday_adapter: bogus)
+      handler = client.instance_variable_get(:@connection).builder.adapter
+      expect(handler.klass).to eq(Faraday::Adapter.lookup_middleware(Faraday.default_adapter))
+
+    end
+
+    it 'reports the EFFECTIVE adapter in the INFO log, not the requested one' do
+
+      log_io = StringIO.new
+      logger = Logger.new(log_io).tap { |l| l.level = Logger::INFO }
+      GetStreamRuby.manual(api_key: 'k', api_secret: 's', faraday_adapter: bogus, logger: logger)
+      info_lines = log_io.string.lines.select { |l| l.include?('INFO') }
+      expect(info_lines.size).to eq(1)
+      expect(info_lines.first).to include("faraday_adapter=#{Faraday.default_adapter}")
+      expect(info_lines.first).not_to include("faraday_adapter=#{bogus}")
+
+    end
+
+  end
+
   describe 'INFO log on construction' do
 
     let(:log_io) { StringIO.new }

--- a/spec/connection_pooling_spec.rb
+++ b/spec/connection_pooling_spec.rb
@@ -69,4 +69,45 @@ RSpec.describe 'CHA-2956 connection pooling' do
 
   end
 
+  describe 'per-call request_timeout override (§5.2)' do
+
+    let(:stubs) { Faraday::Adapter::Test::Stubs.new }
+    let(:client) do
+
+      c = GetStreamRuby.manual(
+        api_key: 'k', api_secret: 's',
+        base_url: 'https://chat.stream-io-api.test',
+        request_timeout: 30,
+      )
+      test_conn = Faraday.new(url: c.configuration.base_url) do |conn|
+
+        conn.request :multipart
+        conn.response :json, content_type: /\bjson$/
+        conn.adapter :test, stubs
+
+      end
+      c.instance_variable_set(:@connection, test_conn)
+      c
+
+    end
+
+    it 'overrides per-request timeout for a single call without mutating the client' do
+
+      captured = nil
+      stubs.get('/api/v2/probe') do |env|
+
+        captured = env
+        [200, { 'Content-Type' => 'application/json' }, '{}']
+
+      end
+
+      client.make_request(:get, '/api/v2/probe', request_timeout: 5)
+
+      expect(captured.request.timeout).to eq(5)
+      expect(client.configuration.request_timeout).to eq(30)
+
+    end
+
+  end
+
 end

--- a/spec/connection_pooling_spec.rb
+++ b/spec/connection_pooling_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'faraday/net_http_persistent'
+
+# CHA-2956 connection pooling spec.
+RSpec.describe 'CHA-2956 connection pooling' do
+
+  describe 'defaults' do
+
+    let(:client) { GetStreamRuby.manual(api_key: 'k', api_secret: 's') }
+
+    it 'uses net_http_persistent as the default adapter' do
+
+      handler = client.instance_variable_get(:@connection).builder.adapter
+      expect(handler.klass).to eq(Faraday::Adapter::NetHttpPersistent)
+
+    end
+
+    it 'sets request_timeout and connect_timeout on Faraday options' do
+
+      conn = client.instance_variable_get(:@connection)
+      expect(conn.options.timeout).to eq(30)
+      expect(conn.options.open_timeout).to eq(10)
+
+    end
+
+    it 'passes pool_size=5 to the net_http_persistent adapter' do
+
+      handler = client.instance_variable_get(:@connection).builder.adapter
+      kwargs = handler.instance_variable_get(:@args).last
+      expect(kwargs).to include(pool_size: 5)
+
+    end
+
+  end
+
+  describe 'individual knob overrides' do
+
+    it 'honors max_conns_per_host:' do
+
+      client = GetStreamRuby.manual(api_key: 'k', api_secret: 's', max_conns_per_host: 17)
+      handler = client.instance_variable_get(:@connection).builder.adapter
+      expect(handler.instance_variable_get(:@args).last).to include(pool_size: 17)
+
+    end
+
+    it 'honors connect_timeout:' do
+
+      client = GetStreamRuby.manual(api_key: 'k', api_secret: 's', connect_timeout: 3)
+      expect(client.instance_variable_get(:@connection).options.open_timeout).to eq(3)
+
+    end
+
+    it 'honors request_timeout:' do
+
+      client = GetStreamRuby.manual(api_key: 'k', api_secret: 's', request_timeout: 7)
+      expect(client.instance_variable_get(:@connection).options.timeout).to eq(7)
+
+    end
+
+    it 'keeps timeout: as a backwards-compat alias for request_timeout:' do
+
+      client = GetStreamRuby.manual(api_key: 'k', api_secret: 's', timeout: 11)
+      expect(client.configuration.request_timeout).to eq(11)
+      expect(client.instance_variable_get(:@connection).options.timeout).to eq(11)
+
+    end
+
+  end
+
+end

--- a/spec/connection_pooling_spec.rb
+++ b/spec/connection_pooling_spec.rb
@@ -110,4 +110,46 @@ RSpec.describe 'CHA-2956 connection pooling' do
 
   end
 
+  describe 'escape hatch: http_client (§7)' do
+
+    it 'uses the user-supplied Faraday::Connection as-is' do
+
+      custom = Faraday.new(url: 'https://example.invalid') { |c| c.adapter :test }
+      client = GetStreamRuby.manual(
+        api_key: 'k', api_secret: 's',
+        http_client: custom,
+        # All ignored:
+        max_conns_per_host: 99,
+        idle_timeout: 99,
+        connect_timeout: 99,
+        request_timeout: 99,
+      )
+
+      expect(client.instance_variable_get(:@connection)).to be(custom)
+      expect(custom.builder.adapter.klass).to eq(Faraday::Adapter::Test)
+
+    end
+
+  end
+
+  describe 'escape hatch: faraday_adapter (§7)' do
+
+    it 'uses the custom adapter symbol and does NOT apply pool_size' do
+
+      client = GetStreamRuby.manual(
+        api_key: 'k', api_secret: 's',
+        faraday_adapter: :net_http,
+        max_conns_per_host: 17, # MUST be ignored
+      )
+
+      handler = client.instance_variable_get(:@connection).builder.adapter
+      expect(handler.klass).to eq(Faraday::Adapter::NetHttp)
+      kwargs = handler.instance_variable_get(:@args).last
+      kwargs = {} unless kwargs.is_a?(Hash)
+      expect(kwargs).not_to include(pool_size: 17)
+
+    end
+
+  end
+
 end

--- a/spec/connection_pooling_spec.rb
+++ b/spec/connection_pooling_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'CHA-2956 connection pooling' do
       c = GetStreamRuby.manual(
         api_key: 'k', api_secret: 's',
         base_url: 'https://chat.stream-io-api.test',
-        request_timeout: 30,
+        request_timeout: 30
       )
       test_conn = Faraday.new(url: c.configuration.base_url) do |conn|
 
@@ -122,7 +122,7 @@ RSpec.describe 'CHA-2956 connection pooling' do
         max_conns_per_host: 99,
         idle_timeout: 99,
         connect_timeout: 99,
-        request_timeout: 99,
+        request_timeout: 99
       )
 
       expect(client.instance_variable_get(:@connection)).to be(custom)
@@ -139,7 +139,7 @@ RSpec.describe 'CHA-2956 connection pooling' do
       client = GetStreamRuby.manual(
         api_key: 'k', api_secret: 's',
         faraday_adapter: :net_http,
-        max_conns_per_host: 17, # MUST be ignored
+        max_conns_per_host: 17 # MUST be ignored
       )
 
       handler = client.instance_variable_get(:@connection).builder.adapter

--- a/spec/connection_pooling_spec.rb
+++ b/spec/connection_pooling_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'CHA-2956 connection pooling' do
 
   end
 
-  describe 'per-call request_timeout override (§5.2)' do
+  describe 'per-call request_timeout override' do
 
     let(:stubs) { Faraday::Adapter::Test::Stubs.new }
     let(:client) do
@@ -131,7 +131,7 @@ RSpec.describe 'CHA-2956 connection pooling' do
 
   end
 
-  describe 'escape hatch: http_client (§7)' do
+  describe 'escape hatch: http_client' do
 
     it 'uses the user-supplied Faraday::Connection as-is' do
 
@@ -153,7 +153,7 @@ RSpec.describe 'CHA-2956 connection pooling' do
 
   end
 
-  describe 'escape hatch: faraday_adapter (§7)' do
+  describe 'escape hatch: faraday_adapter' do
 
     it 'uses the custom adapter symbol and does NOT apply pool_size' do
 
@@ -174,7 +174,7 @@ RSpec.describe 'CHA-2956 connection pooling' do
 
   end
 
-  describe 'INFO log on construction (§8)' do
+  describe 'INFO log on construction' do
 
     let(:log_io) { StringIO.new }
     let(:logger) { Logger.new(log_io).tap { |l| l.level = Logger::INFO } }

--- a/spec/connection_pooling_spec.rb
+++ b/spec/connection_pooling_spec.rb
@@ -152,4 +152,42 @@ RSpec.describe 'CHA-2956 connection pooling' do
 
   end
 
+  describe 'INFO log on construction (§8)' do
+
+    let(:log_io) { StringIO.new }
+    let(:logger) { Logger.new(log_io).tap { |l| l.level = Logger::INFO } }
+
+    it 'emits exactly one INFO line listing the 5 effective values' do
+
+      GetStreamRuby.manual(api_key: 'k', api_secret: 's', logger: logger)
+      info_lines = log_io.string.lines.select { |l| l.include?('INFO') }
+      expect(info_lines.size).to eq(1)
+      line = info_lines.first
+      expect(line).to include('connection pool')
+      expect(line).to include('max_conns_per_host=5')
+      expect(line).to include('idle_timeout=55')
+      expect(line).to include('connect_timeout=10')
+      expect(line).to include('request_timeout=30')
+      expect(line).to include('user_http_client=false')
+      expect(line).to include('faraday_adapter=default')
+
+    end
+
+    it 'reports user_http_client=true when http_client is supplied' do
+
+      custom = Faraday.new(url: 'https://example.invalid') { |c| c.adapter :test }
+      GetStreamRuby.manual(api_key: 'k', api_secret: 's', logger: logger, http_client: custom)
+      expect(log_io.string).to include('user_http_client=true')
+
+    end
+
+    it 'reports the adapter symbol when faraday_adapter is supplied' do
+
+      GetStreamRuby.manual(api_key: 'k', api_secret: 's', logger: logger, faraday_adapter: :net_http)
+      expect(log_io.string).to include('faraday_adapter=net_http')
+
+    end
+
+  end
+
 end

--- a/spec/getstream_ruby_spec.rb
+++ b/spec/getstream_ruby_spec.rb
@@ -26,6 +26,13 @@ RSpec.describe GetStreamRuby do
       expect(client.configuration.faraday_adapter).to be_nil
       expect(client.configuration.faraday_adapter_options).to eq({})
       expect(client.configuration.connection_keep_alive).to eq(true)
+      expect(client.configuration.max_conns_per_host).to eq(5)
+      expect(client.configuration.idle_timeout).to eq(55)
+      expect(client.configuration.connect_timeout).to eq(10)
+      expect(client.configuration.request_timeout).to eq(30)
+      expect(client.configuration.http_client).to be_nil
+      # Backwards-compat: timeout: kwarg is an alias for request_timeout:.
+      expect(client.configuration.timeout).to eq(30)
 
     end
 

--- a/spec/webhook_spec.rb
+++ b/spec/webhook_spec.rb
@@ -11,7 +11,7 @@ require 'zlib'
 
 require_relative '../lib/getstream_ruby/generated/webhook'
 
-# Top-level constants — pulled out of the RSpec.describe blocks below to avoid
+# Top-level constants, pulled out of the RSpec.describe blocks below to avoid
 # Lint/ConstantDefinitionInBlock. WEBHOOK_FIXTURE_ROOT is evaluated at file-load
 # time so the `Dir.children` iteration below can build the per-fixture contexts.
 WEBHOOK_TEST_SECRET = 'test-webhook-secret'
@@ -1611,7 +1611,7 @@ RSpec.describe 'Webhook conformance', type: :integration do
       # Per CHA-3071 wire format: decode_sqs_payload falls back to raw bytes
       # when base64 decoding fails (uncompressed wire format). For input that
       # is neither valid base64 nor valid JSON nor gzip-prefixed, parse_sqs
-      # still raises InvalidWebhookError — just down the chain at JSON parsing.
+      # still raises InvalidWebhookError, just down the chain at JSON parsing.
       skip 'fixtures not present' unless File.directory?(WEBHOOK_FIXTURE_ROOT)
 
       msg = File.read(File.join(neg_dir('bad_base64'), 'sqs_body.txt')).strip

--- a/spec/webhook_spec.rb
+++ b/spec/webhook_spec.rb
@@ -1283,7 +1283,7 @@ RSpec.describe 'Webhook' do
   end
 
   # ---------------------------------------------------------------------------
-  # Spec §6 helpers + composites: parse_event, gunzip_payload, decode_sqs_payload,
+  # Helpers + composites: parse_event, gunzip_payload, decode_sqs_payload,
   # decode_sns_payload, verify_and_parse_webhook, parse_sqs, parse_sns.
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Connection pooling for getstream-ruby (CHA-2956).

- Switches the default Faraday adapter from `Faraday.default_adapter` (no pool) to `:net_http_persistent` (real per-process pool). Matches legacy `stream-chat-ruby`.
- 4 new constructor kwargs: `max_conns_per_host:` (5), `idle_timeout:` (55s), `connect_timeout:` (10s), `request_timeout:` (30s).
- `http_client:` escape hatch: accepts a pre-built `Faraday::Connection` used as-is.
- Per-call `request_timeout:` override on `Client#make_request`.
- One INFO log on construction listing the effective pool config.
- Existing `faraday_adapter` config remains as an alternate escape hatch (pool knobs not applied when set).
- Existing `timeout:` kwarg remains as a backwards-compat alias.

## New runtime deps

- `faraday-net_http_persistent ~> 2.3`
- `net-http-persistent ~> 4.0`

Versions match `stream-chat-ruby/stream-chat.gemspec`.

A Gemfile-only constraint `connection_pool < 3.0` was added because `connection_pool 3.x` requires Ruby >= 3.4 while CI runs Ruby 3.1. `net-http-persistent` accepts `connection_pool >= 2.2.4, < 4`, so the pin is safe.

## Behavior change

- Long-lived processes will now hold up to 5 idle TCP connections per upstream host until they age out at 55s.
- `Connection: keep-alive` header no longer emitted on the default path (net_http_persistent keeps connections alive natively).

## Test plan

- [x] Defaults: `max_conns_per_host=5`, `idle_timeout=55`, `connect_timeout=10`, `request_timeout=30`, adapter is `NetHttpPersistent`
- [x] Each knob individually overridable
- [x] `timeout:` kwarg still works as alias for `request_timeout:`
- [x] `http_client:` escape hatch: user-supplied connection used verbatim
- [x] `faraday_adapter:` escape hatch: custom adapter used; `pool_size` NOT passed
- [x] Per-call `request_timeout:` on `make_request` overrides client default
- [x] INFO log fires once on construction
- [x] `bundle exec rspec spec/` (excluding integration) green: 248 examples, 0 failures
- [x] `bundle exec rubocop` clean: 36 files inspected, no offenses detected
- [x] `bundle exec bundler-audit`: only pre-existing advisories on `addressable`/`faraday`/`yard` (same as master). New `net-http-persistent` and `faraday-net_http_persistent` have no advisories.
- [x] Smoke test: `bundle exec ruby -Ilib -rgetstream_ruby -e 'GetStreamRuby.manual(...)'` prints expected INFO line and `adapter=Faraday::Adapter::NetHttpPersistent`.

## Refs

- Linear: CHA-2956
- Legacy reference: `stream-chat-ruby/lib/stream-chat/client.rb:64-72`