### PR TITLE
feat: [CHA-2958] server-side error handling

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,7 +52,12 @@ Metrics/MethodLength:
     - 'lib/getstream_ruby/generated/**/*'
 
 Metrics/ClassLength:
-  Max: 200
+  Max: 250
+  Exclude:
+    - 'lib/getstream_ruby/generated/**/*'
+
+Metrics/ParameterLists:
+  Max: 8 # ApiError mirrors the canonical APIError envelope (CHA-2958 §5.1)
   Exclude:
     - 'lib/getstream_ruby/generated/**/*'
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,7 +57,7 @@ Metrics/ClassLength:
     - 'lib/getstream_ruby/generated/**/*'
 
 Metrics/ParameterLists:
-  Max: 8 # ApiError mirrors the canonical APIError envelope (CHA-2958 §5.1)
+  Max: 8 # ApiError mirrors the canonical APIError envelope.
   Exclude:
     - 'lib/getstream_ruby/generated/**/*'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
 
-### Added (CHA-2958 server-side error handling)
+### Added
 
 - New error class hierarchy under `GetStreamRuby`:
     * `StreamError < StandardError`. Abstract base for every SDK-raised exception.
@@ -11,13 +11,13 @@
 - New `Client#wait_for_task(task_id, poll_interval: 1, timeout: 60)` helper. Polls `/api/v2/tasks/:id` and: returns the task `result` payload when status reaches `completed`; raises `TaskError` when status reaches `failed`; raises `TransportError` with `error_type: "timeout"` when the deadline elapses.
 - `Client#post` (and the multipart upload path) now deserialize the full canonical `APIError` envelope (`code`, `message`, `exception_fields`, `more_info`, `StatusCode`, `details`, `unrecoverable`, `duration`) and populate the new `ApiError` attributes.
 
-### Changed (CHA-2958)
+### Changed
 
 - The old `GetStreamRuby::APIError` constant remains as a deprecated alias for `GetStreamRuby::ApiError` for one minor cycle, slated for removal in v9.0. First access emits a one-time `Kernel.warn` deprecation notice.
 - The old `GetStreamRuby::Error` constant is preserved as an alias for `StreamError`. Existing `rescue GetStreamRuby::Error` clauses continue to match.
 - Pre-flight multipart validation (`file name must be provided`, `file not found`) now raises `ArgumentError` instead of the old `APIError`. These are caller-side programming errors and don't belong on the API-error surface.
 
-### Webhook helpers (CHA-2961)
+### Webhook helpers
 
 - Webhook handling spec helpers (CHA-2961): `UnknownEvent` class for forward-compat;
   `gunzip_payload`, `decode_sqs_payload`, `decode_sns_payload` primitives;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 ## [Unreleased]
 
-### Added
+### Added (CHA-2958 server-side error handling)
+
+- New error class hierarchy under `GetStreamRuby`:
+    * `StreamError < StandardError`. Abstract base for every SDK-raised exception.
+    * `ApiError < StreamError`. Raised on any HTTP 4xx/5xx, and on responses whose body cannot be parsed as the canonical `APIError` envelope. Exposes `status_code`, `code`, `message`, `exception_fields`, `unrecoverable`, `raw_response_body`, `more_info`, `details`. Previously only `message` survived.
+    * `RateLimitError < ApiError`. Raised on HTTP 429. Adds `retry_after` (Float seconds, nil when the header is absent). Parses the `Retry-After` response header per RFC 7231 in both integer-seconds and HTTP-date forms. Past HTTP-dates clamp to 0.
+    * `TransportError < StreamError`. Raised when no HTTP response is received (connection reset, timeout, TLS handshake failure, DNS failure). Exposes `error_type` from the enum `connection_reset`, `timeout`, `dns_failure`, `tls_handshake_failed`, `unknown`. Always raised inside the matching `rescue Faraday::Error` block, so `Exception#cause` is set to the underlying Faraday error.
+    * `TaskError < StreamError`. Raised by `wait_for_task` when an async task finishes with `status="failed"`. Exposes `task_id`, `error_type`, `description`, `stack_trace`, `version`.
+- New `Client#wait_for_task(task_id, poll_interval: 1, timeout: 60)` helper. Polls `/api/v2/tasks/:id` and: returns the task `result` payload when status reaches `completed`; raises `TaskError` when status reaches `failed`; raises `TransportError` with `error_type: "timeout"` when the deadline elapses.
+- `Client#post` (and the multipart upload path) now deserialize the full canonical `APIError` envelope (`code`, `message`, `exception_fields`, `more_info`, `StatusCode`, `details`, `unrecoverable`, `duration`) and populate the new `ApiError` attributes.
+
+### Changed (CHA-2958)
+
+- The old `GetStreamRuby::APIError` constant remains as a deprecated alias for `GetStreamRuby::ApiError` for one minor cycle, slated for removal in v9.0. First access emits a one-time `Kernel.warn` deprecation notice.
+- The old `GetStreamRuby::Error` constant is preserved as an alias for `StreamError`. Existing `rescue GetStreamRuby::Error` clauses continue to match.
+- Pre-flight multipart validation (`file name must be provided`, `file not found`) now raises `ArgumentError` instead of the old `APIError`. These are caller-side programming errors and don't belong on the API-error surface.
+
+### Webhook helpers (CHA-2961)
 
 - Webhook handling spec helpers (CHA-2961): `UnknownEvent` class for forward-compat;
   `gunzip_payload`, `decode_sqs_payload`, `decode_sns_payload` primitives;
@@ -22,10 +39,6 @@
   `parse_sns(notification_body)` (no signature; AWS IAM).
 - Conformance fixture suite under `test/fixtures/webhooks/` (14 event-type buckets plus
   `_invalid/` negative cases).
-
-### Changed
-
-- No breaking changes.
 
 ### Fixed
 

--- a/lib/getstream_ruby/client.rb
+++ b/lib/getstream_ruby/client.rb
@@ -17,7 +17,9 @@ require_relative 'generated/video_client'
 require_relative 'extensions/moderation_extensions'
 require_relative 'generated/feed'
 require_relative 'generated/webhook'
+require_relative 'generated/models/api_error'
 require_relative 'stream_response'
+require_relative 'error_mapping'
 
 module GetStreamRuby
 
@@ -134,6 +136,49 @@ module GetStreamRuby
       request(:post, path, body)
     end
 
+    # Polls the task-status endpoint until the task reaches a terminal state.
+    #
+    # Behaviour:
+    #   - status="completed": returns the task `result` payload.
+    #   - status="failed":    raises `TaskError` populated from the task's
+    #                         `ErrorResult` (`type`, `description`, `stacktrace`,
+    #                         `version`).
+    #   - timeout elapsed:    raises `TransportError` with `error_type:
+    #                         "timeout"`.
+    #
+    # @param task_id [String]
+    # @param poll_interval [Numeric] seconds between polls (default 1)
+    # @param timeout [Numeric] max seconds to wait (default 60)
+    # @return [Object] the task `result` payload on success
+    # @raise [TaskError] when the task reports `status="failed"`
+    # @raise [TransportError] when the timeout elapses (`error_type="timeout"`)
+    def wait_for_task(task_id, poll_interval: 1, timeout: 60)
+      start_time = monotonic_now
+
+      loop do
+
+        response = common.get_task(task_id)
+        status = response.status
+
+        case status
+        when 'completed'
+          return response.result
+        when 'failed'
+          raise ErrorMapping.build_task_error(task_id, response.error)
+        end
+
+        if monotonic_now - start_time >= timeout
+          raise TransportError.new(
+            "wait_for_task timed out after #{timeout}s for task_id=#{task_id}",
+            error_type: 'timeout',
+          )
+        end
+
+        sleep(poll_interval)
+
+      end
+    end
+
     def make_request(method, path, query_params: nil, body: nil, request_timeout: nil)
       # Handle query parameters
       if query_params && !query_params.empty?
@@ -168,7 +213,7 @@ module GetStreamRuby
 
       handle_response(response)
     rescue Faraday::Error => e
-      raise APIError, "Request failed: #{e.message}"
+      raise TransportError.new("Request failed: #{e.message}", error_type: ErrorMapping.classify_faraday_error(e))
     end
 
     def build_connection
@@ -242,29 +287,13 @@ module GetStreamRuby
     end
 
     def handle_response(response)
-      case response.status
-      when 200..299
-        StreamResponse.new(response.body)
-      else
-        # Parse JSON response body if it's a string
-        parsed_body = if response.body.is_a?(String)
-                        begin
-                          JSON.parse(response.body)
-                        rescue JSON::ParserError
-                          response.body
-                        end
-                      else
-                        response.body
-                      end
+      return StreamResponse.new(response.body) if (200..299).cover?(response.status)
 
-        error_message = if parsed_body.is_a?(Hash)
-                          parsed_body['message'] || parsed_body['detail'] ||
-                            "Request failed with status #{response.status}"
-                        else
-                          "Request failed with status #{response.status}"
-                        end
-        raise APIError, error_message
-      end
+      ErrorMapping.raise_api_error(response)
+    end
+
+    def monotonic_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
 
     def multipart_request?(data)
@@ -280,10 +309,10 @@ module GetStreamRuby
       payload = {}
 
       # Handle file field
-      raise APIError, 'file name must be provided' if data.file.nil? || data.file.empty?
+      raise ArgumentError, 'file name must be provided' if data.file.nil? || data.file.empty?
 
       file_path = data.file
-      raise APIError, "file not found: #{file_path}" unless File.exist?(file_path)
+      raise ArgumentError, "file not found: #{file_path}" unless File.exist?(file_path)
 
       # Determine content type
       content_type = detect_content_type(file_path)
@@ -319,7 +348,7 @@ module GetStreamRuby
 
       handle_response(response)
     rescue Faraday::Error => e
-      raise APIError, "Request failed: #{e.message}"
+      raise TransportError.new("Request failed: #{e.message}", error_type: ErrorMapping.classify_faraday_error(e))
     end
 
     def detect_content_type(file_path)

--- a/lib/getstream_ruby/error_mapping.rb
+++ b/lib/getstream_ruby/error_mapping.rb
@@ -126,7 +126,7 @@ module GetStreamRuby
 
     def build_task_error(task_id, error_payload)
       hash = if error_payload.respond_to?(:to_h)
-               error_payload.to_h || {}
+               error_payload.to_h
              else
                error_payload || {}
              end

--- a/lib/getstream_ruby/error_mapping.rb
+++ b/lib/getstream_ruby/error_mapping.rb
@@ -5,9 +5,7 @@ require 'time'
 
 module GetStreamRuby
 
-  # Pure helpers that translate HTTP responses and Faraday errors into the
-  # SDK error hierarchy. Kept out of `Client` so the class stays focused on
-  # request orchestration.
+  # Translates HTTP responses and Faraday errors into SDK exceptions.
   module ErrorMapping
 
     module_function
@@ -32,7 +30,6 @@ module GetStreamRuby
         raise ApiError.new(**attrs)
       end
 
-      # HTTP response received but body is not a parseable APIError envelope.
       raise ApiError.new(
         message: 'failed to parse error response',
         status_code: response.status,
@@ -82,9 +79,8 @@ module GetStreamRuby
       headers[name] || headers[name.downcase] || headers[name.to_s]
     end
 
-    # Parses an HTTP `Retry-After` header per RFC 7231. Returns a Float number
-    # of seconds, or nil when the header is absent or unparseable. Past
-    # HTTP-dates clamp to 0.
+    # Parse Retry-After header. Returns Float seconds. Returns nil when absent or
+    # unparseable. Past HTTP-dates clamp to 0.
     def parse_retry_after(header)
       return nil if header.nil?
 

--- a/lib/getstream_ruby/error_mapping.rb
+++ b/lib/getstream_ruby/error_mapping.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'time'
+
+module GetStreamRuby
+
+  # Pure helpers that translate HTTP responses and Faraday errors into the
+  # SDK error hierarchy. Kept out of `Client` so the class stays focused on
+  # request orchestration.
+  module ErrorMapping
+
+    module_function
+
+    # Raises the appropriate `ApiError` / `RateLimitError` for a non-2xx
+    # `Faraday::Response`.
+    def raise_api_error(response)
+      parsed_body = parse_error_body(response.body)
+      raw_body = stringify_body(response.body)
+
+      if parsed_body.is_a?(Hash)
+        api_error = GetStream::Generated::Models::APIError.new(parsed_body)
+        attrs = api_error_attrs(api_error, response.status, raw_body)
+
+        if response.status == 429
+          raise RateLimitError.new(
+            retry_after: parse_retry_after(response_header(response, 'Retry-After')),
+            **attrs,
+          )
+        end
+
+        raise ApiError.new(**attrs)
+      end
+
+      # HTTP response received but body is not a parseable APIError envelope.
+      raise ApiError.new(
+        message: 'failed to parse error response',
+        status_code: response.status,
+        code: 0,
+        exception_fields: {},
+        unrecoverable: false,
+        raw_response_body: raw_body,
+        more_info: nil,
+        details: nil,
+      )
+    end
+
+    def api_error_attrs(model, status, raw_body)
+      {
+        message: model.message || "Request failed with status #{status}",
+        status_code: status,
+        code: model.code || 0,
+        exception_fields: model.exception_fields || {},
+        unrecoverable: model.unrecoverable.nil? ? false : model.unrecoverable,
+        raw_response_body: raw_body,
+        more_info: model.more_info,
+        details: model.details,
+      }
+    end
+
+    def parse_error_body(body)
+      return body if body.is_a?(Hash)
+      return nil unless body.is_a?(String) && !body.empty?
+
+      JSON.parse(body)
+    rescue JSON::ParserError
+      nil
+    end
+
+    def stringify_body(body)
+      return '' if body.nil?
+      return body if body.is_a?(String)
+
+      body.to_json
+    end
+
+    def response_header(response, name)
+      headers = response.headers
+      return nil if headers.nil?
+
+      # Faraday normalizes header names to lowercase, but tolerate either form.
+      headers[name] || headers[name.downcase] || headers[name.to_s]
+    end
+
+    # Parses an HTTP `Retry-After` header per RFC 7231. Returns a Float number
+    # of seconds, or nil when the header is absent or unparseable. Past
+    # HTTP-dates clamp to 0.
+    def parse_retry_after(header)
+      return nil if header.nil?
+
+      value = header.to_s.strip
+      return nil if value.empty?
+      return value.to_f if value.match?(/\A\d+\z/)
+
+      begin
+        target = Time.httpdate(value)
+        delta = target - Time.now
+        delta.negative? ? 0.0 : delta.to_f
+      rescue ArgumentError
+        nil
+      end
+    end
+
+    def classify_faraday_error(error)
+      case error
+      when Faraday::TimeoutError
+        'timeout'
+      when Faraday::SSLError
+        'tls_handshake_failed'
+      when Faraday::ConnectionFailed
+        classify_connection_failure(error)
+      else
+        'unknown'
+      end
+    end
+
+    def classify_connection_failure(error)
+      wrapped = error.respond_to?(:wrapped_exception) ? error.wrapped_exception : nil
+      case wrapped
+      when SocketError
+        'dns_failure'
+      else
+        'connection_reset'
+      end
+    end
+
+    def build_task_error(task_id, error_payload)
+      hash = if error_payload.respond_to?(:to_h)
+               error_payload.to_h || {}
+             else
+               error_payload || {}
+             end
+      TaskError.new(
+        task_id: task_id,
+        error_type: lookup(hash, :type) || '',
+        description: lookup(hash, :description) || '',
+        stack_trace: lookup(hash, :stacktrace),
+        version: lookup(hash, :version),
+      )
+    end
+
+    def lookup(hash, key)
+      hash[key] || hash[key.to_s]
+    end
+
+  end
+
+end

--- a/lib/getstream_ruby/errors.rb
+++ b/lib/getstream_ruby/errors.rb
@@ -2,8 +2,112 @@
 
 module GetStreamRuby
 
-  class Error < StandardError; end
-  class ConfigurationError < Error; end
-  class APIError < Error; end
+  # Base error class for the SDK. Every SDK-raised exception is a subclass.
+  class StreamError < StandardError; end
+
+  # Back-compat alias. The prior base class was `Error`; keep it usable so
+  # any existing `rescue GetStreamRuby::Error` clauses keep matching.
+  Error = StreamError
+
+  class ConfigurationError < StreamError; end
+
+  # Raised on any HTTP 4xx/5xx response. Also raised when an HTTP response is
+  # received but its body is not a parseable `APIError` envelope, with `code = 0`
+  # and `message = "failed to parse error response"`.
+  class ApiError < StreamError
+
+    attr_reader :status_code, :code, :exception_fields, :unrecoverable,
+                :raw_response_body, :more_info, :details
+
+    def initialize(message:, status_code:, code:, exception_fields: nil,
+                   unrecoverable: nil, raw_response_body: nil,
+                   more_info: nil, details: nil)
+      super(message)
+      @status_code = status_code
+      @code = code
+      @exception_fields = exception_fields || {}
+      @unrecoverable = unrecoverable.nil? ? false : unrecoverable
+      @raw_response_body = raw_response_body || ''
+      @more_info = more_info
+      @details = details
+    end
+
+  end
+
+  # Raised on HTTP 429. Adds parsed `Retry-After` as Float seconds, or nil when
+  # the header is absent or unparseable. Per RFC 7231, both integer-seconds and
+  # HTTP-date forms are supported. Past HTTP-dates clamp to 0.
+  class RateLimitError < ApiError
+
+    attr_reader :retry_after
+
+    def initialize(retry_after: nil, **kwargs)
+      super(**kwargs)
+      @retry_after = retry_after
+    end
+
+  end
+
+  # Allowed values for `TransportError#error_type`.
+  TRANSPORT_ERROR_TYPES = %w[
+    connection_reset
+    timeout
+    dns_failure
+    tls_handshake_failed
+    unknown
+  ].freeze
+
+  # Raised when no HTTP response is received: connection reset, timeout, TLS
+  # handshake failure, DNS failure. Always raised inside the matching `rescue`
+  # block so Ruby auto-sets `Exception#cause` to the underlying Faraday error.
+  class TransportError < StreamError
+
+    attr_reader :error_type
+
+    def initialize(message = nil, error_type: 'unknown')
+      super(message)
+      @error_type = error_type
+    end
+
+  end
+
+  # Raised by `Client#wait_for_task` when an async task finishes with
+  # status="failed". Carries the populated `ErrorResult` fields.
+  class TaskError < StreamError
+
+    attr_reader :task_id, :error_type, :description, :stack_trace, :version
+
+    def initialize(task_id:, error_type:, description:,
+                   stack_trace: nil, version: nil)
+      super(description)
+      @task_id = task_id
+      @error_type = error_type
+      @description = description
+      @stack_trace = stack_trace
+      @version = version
+    end
+
+  end
+
+  # Deprecated alias for ApiError. Will be removed in v9.0.
+  # Implemented via `const_missing` so the first access emits a `Kernel.warn`
+  # once-only and the constant is cached afterwards (no per-rescue noise).
+  @apierror_alias_warned = false
+
+  def self.const_missing(name)
+    if name == :APIError
+      unless @apierror_alias_warned
+        Kernel.warn(
+          '[DEPRECATION] GetStreamRuby::APIError is renamed to ' \
+          'GetStreamRuby::ApiError. The old constant will be removed in v9.0.',
+        )
+        @apierror_alias_warned = true
+      end
+      const_set(:APIError, ApiError)
+      ApiError
+    else
+      super
+    end
+  end
 
 end

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -1,0 +1,478 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'stringio'
+require 'time'
+
+# Error handling spec.
+RSpec.describe 'GetStreamRuby error handling' do
+
+  describe 'class hierarchy' do
+
+    it 'StreamError descends from StandardError' do
+
+      expect(GetStreamRuby::StreamError.ancestors).to include(StandardError)
+
+    end
+
+    it 'ApiError descends from StreamError' do
+
+      expect(GetStreamRuby::ApiError.ancestors).to include(GetStreamRuby::StreamError)
+
+    end
+
+    it 'RateLimitError descends from ApiError (and from StreamError)' do
+
+      expect(GetStreamRuby::RateLimitError.ancestors).to include(GetStreamRuby::ApiError)
+      expect(GetStreamRuby::RateLimitError.ancestors).to include(GetStreamRuby::StreamError)
+
+    end
+
+    it 'TransportError descends from StreamError' do
+
+      expect(GetStreamRuby::TransportError.ancestors).to include(GetStreamRuby::StreamError)
+
+    end
+
+    it 'TaskError descends from StreamError' do
+
+      expect(GetStreamRuby::TaskError.ancestors).to include(GetStreamRuby::StreamError)
+
+    end
+
+    it 'keeps the legacy GetStreamRuby::Error alias as a backward-compat catch-all' do
+
+      expect(GetStreamRuby::Error).to eq(GetStreamRuby::StreamError)
+
+    end
+
+  end
+
+  describe 'APIError back-compat alias' do
+
+    before do
+
+      # Reset the once-warned flag so each test sees a fresh state.
+      GetStreamRuby.instance_variable_set(:@apierror_alias_warned, false)
+      GetStreamRuby.send(:remove_const, :APIError) if GetStreamRuby.const_defined?(:APIError, false)
+
+    end
+
+    it 'resolves to ApiError' do
+
+      original_stderr = $stderr
+      $stderr = StringIO.new
+      begin
+        expect(GetStreamRuby::APIError).to eq(GetStreamRuby::ApiError)
+      ensure
+        $stderr = original_stderr
+      end
+
+    end
+
+    it 'emits a Kernel.warn deprecation on first access only' do
+
+      messages = []
+      allow(Kernel).to receive(:warn) { |msg| messages << msg }
+
+      _first = GetStreamRuby::APIError
+      _second = GetStreamRuby::APIError
+
+      expect(messages.size).to eq(1)
+      expect(messages.first).to include('APIError')
+      expect(messages.first).to include('deprecated').or include('renamed')
+
+    end
+
+  end
+
+  describe 'ApiError fields' do
+
+    let(:err) do
+
+      GetStreamRuby::ApiError.new(
+        message: 'boom',
+        status_code: 400,
+        code: 4,
+        exception_fields: { 'user_id' => 'required' },
+        unrecoverable: true,
+        raw_response_body: '{"code":4}',
+        more_info: 'https://docs.example/4',
+        details: ['x'],
+      )
+
+    end
+
+    it 'exposes all eight fields plus the message' do
+
+      expect(err.message).to eq('boom')
+      expect(err.status_code).to eq(400)
+      expect(err.code).to eq(4)
+      expect(err.exception_fields).to eq('user_id' => 'required')
+      expect(err.unrecoverable).to be(true)
+      expect(err.raw_response_body).to eq('{"code":4}')
+      expect(err.more_info).to eq('https://docs.example/4')
+      expect(err.details).to eq(['x'])
+
+    end
+
+    it 'defaults exception_fields to {} and unrecoverable to false' do
+
+      e = GetStreamRuby::ApiError.new(message: 'm', status_code: 500, code: 0)
+      expect(e.exception_fields).to eq({})
+      expect(e.unrecoverable).to be(false)
+      expect(e.raw_response_body).to eq('')
+
+    end
+
+  end
+
+  describe 'TaskError fields' do
+
+    let(:err) do
+
+      GetStreamRuby::TaskError.new(
+        task_id: 't-1',
+        error_type: 'panic',
+        description: 'died',
+        stack_trace: 'stack',
+        version: '1.0',
+      )
+
+    end
+
+    it 'exposes attributes and uses description as the message' do
+
+      expect(err.task_id).to eq('t-1')
+      expect(err.error_type).to eq('panic')
+      expect(err.description).to eq('died')
+      expect(err.message).to eq('died')
+      expect(err.stack_trace).to eq('stack')
+      expect(err.version).to eq('1.0')
+
+    end
+
+  end
+
+  describe 'TransportError cause-chain preservation' do
+
+    it 'sets Exception#cause when raised inside a Faraday rescue block' do
+
+      err = begin
+        begin
+          raise Faraday::ConnectionFailed, 'reset'
+        rescue Faraday::Error
+          raise GetStreamRuby::TransportError.new('wrapped', error_type: 'connection_reset')
+        end
+      rescue GetStreamRuby::TransportError => e
+        e
+      end
+
+      expect(err.cause).to be_a(Faraday::ConnectionFailed)
+      expect(err.error_type).to eq('connection_reset')
+
+    end
+
+  end
+
+end
+
+RSpec.describe 'GetStreamRuby::Client error wrapping' do
+
+  let(:stubs) { Faraday::Adapter::Test::Stubs.new }
+  let(:base_url) { 'https://chat.stream-io-api.test' }
+  let(:client) do
+
+    c = GetStreamRuby.manual(api_key: 'k', api_secret: 's', base_url: base_url)
+    test_conn = Faraday.new(url: base_url) do |conn|
+
+      conn.request :multipart
+      conn.response :json, content_type: /\bjson$/
+      conn.adapter :test, stubs
+
+    end
+    c.instance_variable_set(:@connection, test_conn)
+    c
+
+  end
+
+  describe '4xx with an APIError envelope' do
+
+    it 'raises ApiError populated from the response body' do
+
+      body = {
+        code: 4,
+        message: 'invalid input',
+        exception_fields: { 'user_id' => 'required' },
+        more_info: 'https://getstream.io/docs',
+        unrecoverable: true,
+        StatusCode: 400,
+        details: [1, 2],
+        duration: '3ms',
+      }
+      stubs.post('/api/v2/test') { [400, { 'Content-Type' => 'application/json' }, body.to_json] }
+
+      expect { client.post('/api/v2/test') }.to raise_error(GetStreamRuby::ApiError) do |err|
+
+        expect(err.status_code).to eq(400)
+        expect(err.code).to eq(4)
+        expect(err.message).to eq('invalid input')
+        expect(err.exception_fields).to eq('user_id' => 'required')
+        expect(err.more_info).to eq('https://getstream.io/docs')
+        expect(err.unrecoverable).to be(true)
+        expect(err.details).to eq([1, 2])
+        expect(err.raw_response_body).not_to be_empty
+
+      end
+
+    end
+
+  end
+
+  describe '429 rate-limit' do
+
+    let(:body) { { code: 9, message: 'slow down', StatusCode: 429 }.to_json }
+
+    it 'raises RateLimitError with Retry-After parsed as integer seconds' do
+
+      stubs.post('/api/v2/rl') { [429, { 'Content-Type' => 'application/json', 'Retry-After' => '30' }, body] }
+
+      expect { client.post('/api/v2/rl') }.to raise_error(GetStreamRuby::RateLimitError) do |err|
+
+        expect(err.retry_after).to be_within(0.0001).of(30.0)
+        expect(err.status_code).to eq(429)
+        expect(err.code).to eq(9)
+
+      end
+
+    end
+
+    it 'raises RateLimitError with Retry-After parsed as HTTP-date' do
+
+      future = Time.now + 45
+      headers = { 'Content-Type' => 'application/json', 'Retry-After' => future.httpdate }
+      stubs.post('/api/v2/rl') { [429, headers, body] }
+
+      expect { client.post('/api/v2/rl') }.to raise_error(GetStreamRuby::RateLimitError) do |err|
+
+        expect(err.retry_after).to be > 0
+        expect(err.retry_after).to be <= 46.0
+
+      end
+
+    end
+
+    it 'clamps a past HTTP-date Retry-After to 0' do
+
+      past = Time.now - 60
+      headers = { 'Content-Type' => 'application/json', 'Retry-After' => past.httpdate }
+      stubs.post('/api/v2/rl') { [429, headers, body] }
+
+      expect { client.post('/api/v2/rl') }.to raise_error(GetStreamRuby::RateLimitError) do |err|
+
+        expect(err.retry_after).to eq(0.0)
+
+      end
+
+    end
+
+    it 'leaves retry_after nil when the header is absent' do
+
+      stubs.post('/api/v2/rl') { [429, { 'Content-Type' => 'application/json' }, body] }
+
+      expect { client.post('/api/v2/rl') }.to raise_error(GetStreamRuby::RateLimitError) do |err|
+
+        expect(err.retry_after).to be_nil
+
+      end
+
+    end
+
+    it 'is still rescuable as ApiError (inheritance check)' do
+
+      stubs.post('/api/v2/rl') { [429, { 'Content-Type' => 'application/json' }, body] }
+      expect { client.post('/api/v2/rl') }.to raise_error(GetStreamRuby::ApiError)
+
+    end
+
+  end
+
+  describe 'unparseable response body' do
+
+    it 'raises ApiError with code=0 and the canonical generic message' do
+
+      stubs.post('/api/v2/x') { [500, { 'Content-Type' => 'text/plain' }, 'oops'] }
+
+      expect { client.post('/api/v2/x') }.to raise_error(GetStreamRuby::ApiError) do |err|
+
+        expect(err.status_code).to eq(500)
+        expect(err.code).to eq(0)
+        expect(err.message).to eq('failed to parse error response')
+        expect(err.raw_response_body).to eq('oops')
+
+      end
+
+    end
+
+  end
+
+  describe 'transport-layer failures' do
+
+    it 'wraps Faraday::ConnectionFailed as TransportError with cause preserved' do
+
+      stubs.post('/api/v2/x') { raise Faraday::ConnectionFailed, 'reset' }
+
+      expect { client.post('/api/v2/x') }.to raise_error(GetStreamRuby::TransportError) do |err|
+
+        expect(err.error_type).to eq('connection_reset')
+        expect(err.cause).to be_a(Faraday::Error)
+
+      end
+
+    end
+
+    it 'classifies Faraday::TimeoutError as timeout' do
+
+      stubs.post('/api/v2/x') { raise Faraday::TimeoutError, 'too slow' }
+
+      expect { client.post('/api/v2/x') }.to raise_error(GetStreamRuby::TransportError) do |err|
+
+        expect(err.error_type).to eq('timeout')
+
+      end
+
+    end
+
+    it 'classifies Faraday::SSLError as tls_handshake_failed' do
+
+      stubs.post('/api/v2/x') { raise Faraday::SSLError, 'bad cert' }
+
+      expect { client.post('/api/v2/x') }.to raise_error(GetStreamRuby::TransportError) do |err|
+
+        expect(err.error_type).to eq('tls_handshake_failed')
+
+      end
+
+    end
+
+    it 'classifies a ConnectionFailed wrapping SocketError as dns_failure' do
+
+      # Pass the underlying exception as the first arg so Faraday::Error
+      # captures it as `wrapped_exception` (its constructor uses the second
+      # positional arg as the response, not the wrapped exception).
+      stubs.post('/api/v2/x') do
+
+        raise Faraday::ConnectionFailed, SocketError.new('Name or service not known')
+
+      end
+
+      expect { client.post('/api/v2/x') }.to raise_error(GetStreamRuby::TransportError) do |err|
+
+        expect(err.error_type).to eq('dns_failure')
+
+      end
+
+    end
+
+  end
+
+end
+
+RSpec.describe 'GetStreamRuby::Client#wait_for_task' do
+
+  let(:stubs) { Faraday::Adapter::Test::Stubs.new }
+  let(:base_url) { 'https://chat.stream-io-api.test' }
+  let(:client) do
+
+    c = GetStreamRuby.manual(api_key: 'k', api_secret: 's', base_url: base_url)
+    test_conn = Faraday.new(url: base_url) do |conn|
+
+      conn.request :multipart
+      conn.response :json, content_type: /\bjson$/
+      conn.adapter :test, stubs
+
+    end
+    c.instance_variable_set(:@connection, test_conn)
+    c
+
+  end
+
+  before { allow(client).to receive(:sleep) }
+
+  it 'returns the result payload when the task completes' do
+
+    counter = 0
+    stubs.get('/api/v2/tasks/abc') do
+
+      counter += 1
+      body = if counter < 2
+
+               { status: 'pending', task_id: 'abc' }
+
+             else
+
+               { status: 'completed', task_id: 'abc', result: { 'ok' => true, 'count' => 3 } }
+
+             end
+      [200, { 'Content-Type' => 'application/json' }, body.to_json]
+
+    end
+
+    result = client.wait_for_task('abc', poll_interval: 0)
+    expect(counter).to be >= 2
+    expect(result.to_h).to eq('ok' => true, 'count' => 3)
+
+  end
+
+  it 'raises TaskError populated from the ErrorResult when the task fails' do
+
+    stubs.get('/api/v2/tasks/abc') do
+
+      body = {
+        status: 'failed',
+        task_id: 'abc',
+        error: {
+          type: 'panic',
+          description: 'worker died',
+          stacktrace: 'goroutine 1 [running]: ...',
+          version: 'v1.2.3',
+        },
+      }
+      [200, { 'Content-Type' => 'application/json' }, body.to_json]
+
+    end
+
+    expect { client.wait_for_task('abc', poll_interval: 0) }.to raise_error(GetStreamRuby::TaskError) do |err|
+
+      expect(err.task_id).to eq('abc')
+      expect(err.error_type).to eq('panic')
+      expect(err.description).to eq('worker died')
+      expect(err.message).to eq('worker died')
+      expect(err.stack_trace).to eq('goroutine 1 [running]: ...')
+      expect(err.version).to eq('v1.2.3')
+
+    end
+
+  end
+
+  it 'raises TransportError(error_type: "timeout") when the deadline elapses' do
+
+    stubs.get('/api/v2/tasks/abc') do
+
+      [200, { 'Content-Type' => 'application/json' }, { status: 'pending', task_id: 'abc' }.to_json]
+
+    end
+
+    err = begin
+      client.wait_for_task('abc', poll_interval: 0, timeout: 0)
+      nil
+    rescue GetStreamRuby::TransportError => e
+      e
+    end
+
+    expect(err).to be_a(GetStreamRuby::TransportError)
+    expect(err.error_type).to eq('timeout')
+
+  end
+
+end


### PR DESCRIPTION
## Summary

- Five new classes under `GetStreamRuby`:
  - `StreamError < StandardError` — base
  - `ApiError < StreamError` — 4xx/5xx envelope + unparseable bodies (status_code, code, exception_fields, unrecoverable, raw_response_body, more_info, details)
  - `RateLimitError < ApiError` — HTTP 429 + parsed `retry_after` (Float seconds, RFC 7231 §7.1.3 integer + HTTP-date)
  - `TransportError < StreamError` — Faraday failures with `error_type` enum (connection_reset / timeout / dns_failure / tls_handshake_failed / unknown); cause preserved via Ruby's automatic `$!.cause`
  - `TaskError < StreamError` — `task_id / error_type / description / stack_trace / version`
- `client.wait_for_task(task_id, poll_interval: 1, timeout: 60)`.
- `Client#handle_response` deserializes the canonical APIError envelope into `ApiError` attributes; only `message` survived previously.

## Back-compat

- `GetStreamRuby::Error` aliased to `StreamError`.
- `GetStreamRuby::APIError` (legacy caps) is a deprecated alias for `ApiError`; first access emits a one-time `Kernel.warn`. Slated for removal in v9.0.
- Pre-flight multipart validation now raises `ArgumentError` (was the old `APIError`).

## Test plan

- [ ] `make test` or `bundle exec rspec spec/errors_spec.rb`
- [ ] `bundle exec rubocop`