### PR TITLE
fix: move test_mode flag on check_user_profile moderation extensions

### DIFF
--- a/lib/getstream_ruby/extensions/moderation_extensions.rb
+++ b/lib/getstream_ruby/extensions/moderation_extensions.rb
@@ -40,7 +40,8 @@ module GetStream
           entity_creator_id: user_id,
           moderation_payload: moderation_payload,
           config_key: config_key,
-          options: { force_sync: true, test_mode: true },
+          options: { force_sync: true },
+          test_mode: true,
         )
 
         check(check_request)


### PR DESCRIPTION
test_mode flag has since been moved to top level of request body - moving it to keep its effect