### PR TITLE
feat!: release structured logging and opt-in auto-retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [9.0.0] - 2026-07-24
+
 ### Added
 
 - New error class hierarchy under `GetStreamRuby`:


### PR DESCRIPTION
Release PR: stamps the accumulated `[Unreleased]` changelog as **v9.0.0** and, on merge, the release workflow bumps the version, tags, and publishes the gem.

Major bump because the retry work removed the always-on faraday-retry middleware (now opt-in via `retry_config:`), a behavior change spelled out in the changelog. `version.rb` is intentionally not touched here (the release workflow owns it). Also includes structured logging and the other accumulated unreleased changes.