### PR TITLE
feat: name the HTTP status when the error body is not JSON

### DIFF
--- a/lib/getstream_ruby/error_mapping.rb
+++ b/lib/getstream_ruby/error_mapping.rb
@@ -31,7 +31,7 @@ module GetStreamRuby
       end
 
       raise ApiError.new(
-        message: 'failed to parse error response',
+        message: "failed to parse error response: unexpected server response code #{response.status}",
         status_code: response.status,
         code: 0,
         exception_fields: {},

--- a/lib/getstream_ruby/errors.rb
+++ b/lib/getstream_ruby/errors.rb
@@ -13,7 +13,8 @@ module GetStreamRuby
 
   # Raised on any HTTP 4xx/5xx response. Also raised when an HTTP response is
   # received but its body is not a parseable `APIError` envelope, with `code = 0`
-  # and `message = "failed to parse error response"`.
+  # and `message = "failed to parse error response: unexpected server response
+  # code <status>"`.
   class ApiError < StreamError
 
     attr_reader :status_code, :code, :exception_fields, :unrecoverable,

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -307,7 +307,7 @@ RSpec.describe 'GetStreamRuby::Client error wrapping' do
 
         expect(err.status_code).to eq(500)
         expect(err.code).to eq(0)
-        expect(err.message).to eq('failed to parse error response')
+        expect(err.message).to eq('failed to parse error response: unexpected server response code 500')
         expect(err.raw_response_body).to eq('oops')
 
       end


### PR DESCRIPTION
## Ticket
https://linear.app/stream/issue/CHA-4641/generated-sdks-report-the-http-status-when-the-error-body-is-not-json

## Summary
When an error body is not JSON, the SDK reported only the parse failure and hid the HTTP status. A customer saw `failed to parse error response` for a 503 that the edge proxy returned as plain text, plus a JSON parse stack trace, and could not tell which status they got. `ApiError#message` now appends the status: `failed to parse error response: unexpected server response code 503`. `status_code`, `raw_response_body` and the cause do not change.

The old text is still the prefix of the new message, so prefix matching and substring matching on it both keep working.

## Verification
- `make test`: 305 examples, 0 failures.
- `make format-check`, `make lint`, `make security`: clean.
